### PR TITLE
Fixed a common race condition regarding memcache usage.

### DIFF
--- a/goon.go
+++ b/goon.go
@@ -123,7 +123,8 @@ func (g *Goon) PutMulti(es []*Entity) error {
 		src[i] = e.Src
 	}
 
-	memcache.DeleteMulti(g.context, memkeys)
+	// Memcache needs to be updated after the datastore to prevent a common race condition
+	defer memcache.DeleteMulti(g.context, memkeys)
 
 	for i := 0; i <= len(src)/putMultiLimit; i++ {
 		lo := i * putMultiLimit
@@ -391,7 +392,8 @@ func (g *Goon) DeleteMulti(keys []*datastore.Key) error {
 		}
 	}
 
-	memcache.DeleteMulti(g.context, memkeys)
+	// Memcache needs to be updated after the datastore to prevent a common race condition
+	defer memcache.DeleteMulti(g.context, memkeys)
 
 	return datastore.DeleteMulti(g.context, keys)
 }


### PR DESCRIPTION
The previous implementations of `Goon.DeleteMulti` and `Goon.PutMulti` had a flaw that made them susceptible to a **common race condition**. Specifically, those functions updated the memcache before the datastore.

To illustrate the race condition, consider three parallel requests.

```
Time       Request #1             Request #2             Request #3
T+000ms    DeleteMulti() starts
T+010ms    memcache cleared
T+020ms                           Get() starts
T+030ms                           memcache updated with entity
T+040ms    datastore cleared
T+050ms                                                  Get() starts
T+060ms                                                  entity read from memcache

---
Result:    entity == nil          entity != nil          entity != nil
```

Like the third request in the example, any further request with a Get() will **incorrectly** belive that the entity still exists, because the cache isn't synchronized with the datastore.

Now, lets look at what happens when my changes are applied.

```
Time       Request #1             Request #2             Request #3
T+000ms    DeleteMulti() starts
T+010ms    memcache deferred
T+020ms                           Get() starts
T+030ms                           memcache updated with entity
T+040ms    datastore cleared
T+050ms    memcache cleared                              Get() starts
T+060ms                                                  no entity found in memcache/datastore

---
Result:    entity == nil          entity != nil          entity == nil
```

Like the third request in the example, any further request with a Get() will belive that the entity does not exist, because the cache is **correctly synchronized** with the datastore.
