### PR TITLE
No longer polluting the cache with empty results from keys-only queries.

### DIFF
--- a/query.go
+++ b/query.go
@@ -71,7 +71,8 @@ func (g *Goon) GetAll(q *datastore.Query, dst interface{}) ([]*Entity, error) {
 		}
 		es[i] = e
 
-		if !g.inTransaction {
+		// Do not pollute the cache with empty results from keys-only queries
+		if !g.inTransaction && !keysOnly {
 			g.cache[e.memkey()] = e
 		}
 	}


### PR DESCRIPTION
The old code cached empty results when a keys-only query was made.

Here's some basic code that demonstrates the problem:

```
g := goon.NewGoon(r)
q := datastore.NewQuery("BugCheck").KeysOnly()
var bcs []*BugCheck
es, _ := g.GetAll(q, &bcs)

e, _ := g.NewEntityById("bug-check-1", 0, nil, &BugCheck{})
e, _ = g.Get(&BugCheck{}, e.Key)

if e.Src == nil {
    // Shouldn't be nil, but is because the keys-only query cached it as such
}
```
