### PR TITLE
Added support to Goon for users to set timeout values for Memcache and Datastore

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -17,13 +17,14 @@
 package goon
 
 import (
-	"appengine/datastore"
 	"bytes"
 	"encoding/gob"
 	"errors"
 	"fmt"
 	"reflect"
 	"strings"
+
+	"appengine/datastore"
 )
 
 func toGob(src interface{}) ([]byte, error) {
@@ -80,6 +81,9 @@ func (g *Goon) getStructKey(src interface{}) (*datastore.Key, error) {
 						return nil, errors.New("goon: Only one field may be marked id")
 					}
 					stringID = vf.String()
+					if stringID == "" {
+						return nil, fmt.Errorf("goon: String id field must be populated in %v", src)
+					}
 				default:
 					return nil, fmt.Errorf("goon: ID field must be int64 or string in %v", t.Name())
 				}

--- a/entity.go
+++ b/entity.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"runtime/debug"
 	"strings"
 
 	"appengine/datastore"
@@ -54,7 +53,6 @@ func (g *Goon) getStructKey(src interface{}) (*datastore.Key, error) {
 	k := t.Kind()
 
 	if k != reflect.Struct {
-		debug.PrintStack()
 		return nil, fmt.Errorf("goon: Expected struct, got instead: %v", k)
 	}
 
@@ -139,7 +137,6 @@ func setStructKey(src interface{}, key *datastore.Key) error {
 	k = t.Kind()
 
 	if k != reflect.Struct {
-		debug.PrintStack()
 		return errors.New(fmt.Sprintf("goon: Expected ptr to struct, got instead ptr to: %v", k))
 	}
 

--- a/goon.go
+++ b/goon.go
@@ -285,6 +285,8 @@ func (g *Goon) putMemcache(srcs []interface{}) error {
 		if err != nil {
 			g.error(err)
 		}
+		// since putMemcache() gives no guarantee it will actually store the data in memcache
+		// we log and swallow this error
 	case <-time.After(MemcachePutTimeout):
 		return ErrMemcacheTimeout
 	}

--- a/goon.go
+++ b/goon.go
@@ -291,11 +291,6 @@ func (g *Goon) putMemcache(srcs []interface{}) error {
 	return nil
 }
 
-type DatastoreResult struct {
-	Keys   []*datastore.Key
-	Values []interface{}
-}
-
 // Get loads the entity based on dst's key into dst
 // If there is no such entity for the key, Get returns
 // datastore.ErrNoSuchEntity.

--- a/goon.go
+++ b/goon.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"reflect"
 	"sync"
+	"time"
 
 	"appengine"
 	"appengine/datastore"
@@ -35,12 +36,14 @@ var (
 
 // Goon holds the app engine context and request memory cache.
 type Goon struct {
-	context       appengine.Context
-	cache         map[string]interface{}
-	cacheLock     sync.RWMutex // protect the cache from concurrent goroutines to speed up RPC access
-	inTransaction bool
-	toSet         map[string]interface{}
-	toDelete      map[string]bool
+	context          appengine.Context
+	cache            map[string]interface{}
+	cacheLock        sync.RWMutex // protect the cache from concurrent goroutines to speed up RPC access
+	inTransaction    bool
+	toSet            map[string]interface{}
+	toDelete         map[string]bool
+	MemcacheTimeout  time.Duration
+	DatastoreTimeout time.Duration
 }
 
 func memkey(k *datastore.Key) string {
@@ -55,13 +58,15 @@ func NewGoon(r *http.Request) *Goon {
 // FromContext creates a new Goon object from the given appengine Context.
 func FromContext(c appengine.Context) *Goon {
 	return &Goon{
-		context: c,
-		cache:   make(map[string]interface{}),
+		context:          c,
+		cache:            make(map[string]interface{}),
+		MemcacheTimeout:  time.Millisecond * 3,
+		DatastoreTimeout: time.Millisecond * 500,
 	}
 }
 
 func (g *Goon) error(err error) {
-	if LogErrors {
+	if LogErrors && err != nil {
 		g.context.Errorf("goon: %v", err.Error())
 	}
 }
@@ -258,16 +263,31 @@ func (g *Goon) putMemcache(srcs []interface{}) error {
 			return err
 		}
 		key, err := g.getStructKey(src)
-
+		if err != nil {
+			return err
+		}
 		items[i] = &memcache.Item{
 			Key:   memkey(key),
 			Value: gob,
 		}
 	}
-
-	memcache.SetMulti(g.context, items)
+	errc := make(chan error, 1) // need to buffer so as to not leak a goroutine
+	go func() {
+		errc <- memcache.SetMulti(g.context, items)
+	}()
 	g.putMemoryMulti(srcs)
+	select {
+	case err := <-errc:
+		g.error(err)
+	case <-time.After(g.MemcacheTimeout):
+		return nil // memcache timeout
+	}
 	return nil
+}
+
+type DatastoreResult struct {
+	Keys   []*datastore.Key
+	Values []interface{}
 }
 
 // Get loads the entity based on dst's key into dst
@@ -311,53 +331,89 @@ func (g *Goon) GetMulti(dst interface{}) error {
 		return datastore.GetMulti(g.context, keys, dst)
 	}
 
-	var dskeys []*datastore.Key
-	var dsdst []interface{}
-	var dixs []int
+	var memkeys []string // a slice of datastore.Key.Encode() that is not in the local cache
+	var mixs []int       // a slice of indexes of dst that represent the memkeys
 
-	var memkeys []string
-	var mixs []int
+	var dskeys []*datastore.Key // a slice of datastore.Key that should be fetched by the datastore
+	var dsdst []interface{}     // a slice of pointers to the destination objects to be filled, index lines up with dskeys
+	var dixs []int              // a slice of indexes of dst that represent the dskeys
 
 	v := reflect.Indirect(reflect.ValueOf(dst))
 	g.cacheLock.RLock()
 	for i, key := range keys {
 		m := memkey(key)
+		vi := v.Index(i)
 		if s, present := g.cache[m]; present {
-			vi := v.Index(i)
 			vi.Set(reflect.ValueOf(s))
 		} else {
 			memkeys = append(memkeys, m)
 			mixs = append(mixs, i)
+			dskeys = append(dskeys, key)
+			dsdst = append(dsdst, vi.Interface())
+			dixs = append(dixs, i)
 		}
 	}
 	g.cacheLock.RUnlock()
 
-	if len(memkeys) == 0 {
+	if len(memkeys) == 0 { // everything was fetched from local cache, return
 		return nil
 	}
 
-	memvalues, _ := memcache.GetMulti(g.context, memkeys)
-	for i, m := range memkeys {
-		d := v.Index(mixs[i]).Interface()
-		if s, present := memvalues[m]; present {
-			err := fromGob(d, s.Value)
-			if err != nil {
-				g.error(err)
-				return err
+	memcacheChan := make(chan map[string]*memcache.Item, 1) // buffer so that we don't leak a goroutine if the request times out
+	datastoreChan := make(chan error, 1)                    // again, buffer so we don't leak go routine
+	datastoreStarted := false
+	memcacheTimeout := time.After(g.MemcacheTimeout)
+	allTimeout := time.After(g.DatastoreTimeout)
+	go func() {
+		memvalues, err := memcache.GetMulti(g.context, memkeys)
+		g.error(err)
+		memcacheChan <- memvalues
+	}()
+	for {
+		select {
+		case memvalues := <-memcacheChan: // memcache has returned
+			//reset the dskeys as memcache succeeded
+			var dskeys []*datastore.Key
+			var dsdst []interface{}
+			var dixs []int
+			for i, m := range memkeys {
+				d := v.Index(mixs[i]).Interface()
+				if s, present := memvalues[m]; present {
+					err := fromGob(d, s.Value)
+					if err != nil {
+						g.error(err)
+						return err
+					}
+					g.putMemory(d) // populate local cache
+				} else {
+					// memcache miss
+					dskeys = append(dskeys, keys[mixs[i]])
+					dsdst = append(dsdst, d)
+					dixs = append(dixs, mixs[i])
+				}
 			}
 
-			g.putMemory(d)
-		} else {
-			dskeys = append(dskeys, keys[mixs[i]])
-			dsdst = append(dsdst, d)
-			dixs = append(dixs, mixs[i])
+			if len(dskeys) == 0 { // everything was fetched from local and memcache, return
+				return nil
+			}
+			if !datastoreStarted { // datastore request may have already been issued if memcache took too long to respond
+				datastoreStarted = true
+				go g.startDatastoreGetMulti(datastoreChan, keys, dskeys, dsdst, dixs)
+			}
+		case err := <-datastoreChan:
+			return err // datastore found the rest of the results and populated memcache
+		case <-memcacheTimeout: //memcache taking too long, start the datastore request
+			if !datastoreStarted { // datastore request may have alredy been started if memcache finished quickly
+				datastoreStarted = true
+				go g.startDatastoreGetMulti(datastoreChan, keys, dskeys, dsdst, dixs)
+			}
+		case <-allTimeout:
+			return fmt.Errorf("goon: timeout - GetMulti took longer than %s to return", g.DatastoreTimeout)
 		}
 	}
-	if len(dskeys) == 0 {
-		return nil
-	}
-
-	multiErr := make(appengine.MultiError, len(keys))
+}
+func (g *Goon) startDatastoreGetMulti(datastoreChan chan error, allKeys, dskeys []*datastore.Key, dsdst []interface{}, dixs []int) {
+	multiErr := make(appengine.MultiError, len(allKeys))
 	var toCache []interface{}
 	var ret error
 	for i := 0; i <= len(dskeys)/getMultiLimit; i++ {
@@ -371,7 +427,8 @@ func (g *Goon) GetMulti(dst interface{}) error {
 			merr, ok := gmerr.(appengine.MultiError)
 			if !ok {
 				g.error(gmerr)
-				return gmerr
+				datastoreChan <- gmerr
+				return
 			}
 			for i, idx := range dixs[lo:hi] {
 				multiErr[idx] = merr[i]
@@ -388,11 +445,12 @@ func (g *Goon) GetMulti(dst interface{}) error {
 	if len(toCache) > 0 {
 		if err := g.putMemcache(toCache); err != nil {
 			g.error(err)
-			return err
+			datastoreChan <- err
+			return
 		}
 	}
 
-	return ret
+	datastoreChan <- ret
 }
 
 // Delete deletes the entity for the given key.

--- a/goon.go
+++ b/goon.go
@@ -461,9 +461,12 @@ func (g *Goon) GetMulti(dst interface{}) error {
 					for i, m := range memkeys {
 						if _, present := memvalues[m]; !present {
 							// memcache miss
-							d := v.Index(mixs[i]).Interface()
+							d := v.Index(mixs[i])
+							if d.Kind() == reflect.Struct {
+								d = d.Addr()
+							}
 							dskeys = append(dskeys, keys[mixs[i]])
-							dsdst = append(dsdst, d)
+							dsdst = append(dsdst, d.Interface())
 							dixs = append(dixs, mixs[i])
 						}
 					}

--- a/goon_test.go
+++ b/goon_test.go
@@ -205,21 +205,21 @@ func TestVariance(t *testing.T) {
 		case "none":
 			// do nothing, use defaults already set
 		case "memcache":
-			g.MemcacheGetTimeout = 0
-			g.MemcachePutTimeout = 0
+			MemcacheGetTimeout = 0
+			MemcachePutTimeout = 0
 		case "datastore":
-			g.MemcacheGetTimeout = time.Millisecond * 2
-			g.MemcachePutTimeout = time.Millisecond * 2
+			MemcacheGetTimeout = time.Millisecond * 2
+			MemcachePutTimeout = time.Millisecond * 2
 			// can't timeout before memcache as memcache doesn't have a chance to return
 			// but the datastore request needs to actually timeout... These times work on my machine consistently
 			// I wasn't sure of a way to write this test any better - @mzimmerman
-			g.DatastoreGetTimeout = time.Millisecond * 2
-			g.DatastorePutTimeout = time.Millisecond * 2
+			DatastoreGetTimeout = time.Millisecond * 2
+			DatastorePutTimeout = time.Millisecond * 2
 		case "both":
-			g.MemcacheGetTimeout = 0
-			g.MemcachePutTimeout = 0
-			g.DatastoreGetTimeout = 0
-			g.DatastorePutTimeout = 0
+			MemcacheGetTimeout = 0
+			MemcachePutTimeout = 0
+			DatastoreGetTimeout = 0
+			DatastorePutTimeout = 0
 		}
 		objects := []*HasId{
 			&HasId{Id: 1, Name: "1"}, // stored in cache, memcache, and datastore

--- a/goon_test.go
+++ b/goon_test.go
@@ -17,7 +17,9 @@
 package goon_test
 
 import (
+	"reflect"
 	"testing"
+	"time"
 
 	"appengine"
 	"appengine/aetest"
@@ -190,6 +192,137 @@ type TwoId struct {
 type PutGet struct {
 	ID    int64 `datastore:"-" goon:"id"`
 	Value int32
+}
+
+func TestVariance(t *testing.T) {
+	c, err := aetest.NewContext(nil)
+	if err != nil {
+		t.Fatalf("Could not start aetest - %v", err)
+	}
+	defer c.Close()
+	g := FromContext(c)
+	timeouts := []string{"none", "memcache", "datastore", "both"} // what services will timeout
+	for _, timeout := range timeouts {
+		switch timeout {
+		case "none":
+			// do nothing, use defaults already set
+		case "memcache":
+			g.MemcacheTimeout = 0
+		case "datastore":
+			g.MemcacheTimeout = time.Millisecond * 2
+			// can't timeout before memcache as memcache doesn't have a chance to return
+			// but the datastore request needs to actually timeout... These times work on my machine consistently
+			// I wasn't sure of a way to write this test any better - @mzimmerman
+			g.DatastoreTimeout = time.Millisecond * 2
+		case "both":
+			g.MemcacheTimeout = 0
+			g.DatastoreTimeout = 0
+		}
+		objects := []*HasId{
+			&HasId{Id: 1, Name: "1"}, // stored in cache, memcache, and datastore
+			&HasId{Id: 2, Name: "2"}, // stored in memcache and datastore
+			&HasId{Id: 3, Name: "3"}, // stored only in datastore
+		}
+		// flush all locations
+		keys, _ := datastore.NewQuery("HasId").KeysOnly().GetAll(c, nil)
+		datastore.DeleteMulti(c, keys)
+		memcache.Flush(c)
+		g.cacheLock.Lock()
+		g.cache = make(map[string]interface{})
+		g.cacheLock.Unlock()
+
+		// add test data to proper locations only
+		for _, obj := range objects {
+			key, _ := g.getStructKey(obj)
+			if _, err := datastore.Put(g.context, key, obj); err != nil {
+				t.Errorf("Error putting object %v", obj)
+			}
+			if obj.Id == 3 {
+				continue
+			}
+			gob, err := toGob(obj)
+			if err != nil {
+				t.Errorf("Unable to gob object - %v", err)
+			}
+			item := &memcache.Item{
+				Key:   memkey(key),
+				Value: gob,
+			}
+			if err = memcache.Set(g.context, item); err != nil {
+				t.Errorf("Error putting object in memcache %v", obj)
+			}
+			if obj.Id == 2 {
+				continue
+			}
+			g.putMemory(obj)
+		}
+
+		datastoreObjects := []*HasId{
+			&HasId{Id: 1, Name: ""}, // stored in cache, memcache, and datastore
+			&HasId{Id: 2, Name: ""}, // stored in memcache and datastore
+			&HasId{Id: 3, Name: ""}, // stored only in datastore
+		}
+		memcacheObjects := []*HasId{
+			&HasId{Id: 1, Name: ""}, // stored in cache, memcache, and datastore
+			&HasId{Id: 2, Name: ""}, // stored in memcache and datastore
+		}
+		cacheObjects := []*HasId{
+			&HasId{Id: 1, Name: ""}, // stored in cache, memcache, and datastore
+		}
+		resultObjects := map[string][]*HasId{
+			"none": []*HasId{
+				&HasId{Id: 1, Name: "1"},
+				&HasId{Id: 2, Name: "2"},
+				&HasId{Id: 3, Name: "3"},
+			},
+			"memcache": []*HasId{
+				&HasId{Id: 1, Name: "1"},
+				&HasId{Id: 2, Name: "2"},
+				&HasId{Id: 3, Name: "3"},
+			},
+			"datastore": []*HasId{
+				&HasId{Id: 1, Name: "1"},
+				&HasId{Id: 2, Name: "2"},
+				&HasId{Id: 3, Name: ""},
+			},
+			"both": []*HasId{
+				&HasId{Id: 1, Name: "1"},
+				&HasId{Id: 2, Name: ""},
+				&HasId{Id: 3, Name: ""},
+			},
+		}
+		cacheGetErr := g.GetMulti(&cacheObjects)
+		memcacheGetErr := g.GetMulti(&memcacheObjects)
+		datastoreGetErr := g.GetMulti(&datastoreObjects)
+		var fetchedObjects []*HasId
+		switch {
+		case timeout == "none":
+			if cacheGetErr != nil || memcacheGetErr != nil || datastoreGetErr != nil {
+				t.Errorf("There are no timeouts, there should be no errors - cache(%v), memcache(%v), datastore(%v)", cacheGetErr, memcacheGetErr, datastoreGetErr)
+			}
+			fetchedObjects = datastoreObjects
+		case timeout == "memcache":
+			if cacheGetErr != nil || memcacheGetErr != nil || datastoreGetErr != nil {
+				t.Errorf("Memcache timeout, but datastore will cover it - cache(%v), memcache(%v), datastore(%v)", cacheGetErr, memcacheGetErr, datastoreGetErr)
+			}
+			fetchedObjects = datastoreObjects // memcache may timeout, but all objects exist in the datastore
+		case timeout == "datastore":
+			if cacheGetErr != nil || memcacheGetErr != nil || datastoreGetErr == nil {
+				t.Errorf("Datastore should timeout - cache(%v), memcache(%v), datastore(%v)", cacheGetErr, memcacheGetErr, datastoreGetErr)
+			}
+			fetchedObjects = memcacheObjects // since the datastore timed out, only memcache objects should exist
+		case timeout == "both":
+			if cacheGetErr != nil || memcacheGetErr == nil || datastoreGetErr == nil {
+				t.Errorf("Memcache && Datastore should timeout - cache(%v), memcache(%v), datastore(%v)", cacheGetErr, memcacheGetErr, datastoreGetErr)
+			}
+			fetchedObjects = cacheObjects // datastore timed out, but there should be no errors fetching only these results
+		}
+		for i := range fetchedObjects {
+			if !reflect.DeepEqual(resultObjects[timeout][i], fetchedObjects[i]) {
+				t.Errorf("%v does not equal %v", resultObjects[timeout][i], fetchedObjects[i])
+			}
+		}
+	}
 }
 
 // This test won't fail but if run with -race flag, it will show known race conditions

--- a/goon_test.go
+++ b/goon_test.go
@@ -384,9 +384,7 @@ func TestVariance(t *testing.T) {
 		keys, _ := datastore.NewQuery("HasId").KeysOnly().GetAll(c, nil)
 		datastore.DeleteMulti(c, keys)
 		memcache.Flush(c)
-		g.cacheLock.Lock()
-		g.cache = make(map[string]interface{})
-		g.cacheLock.Unlock()
+		g.FlushLocalCache()
 
 		// add test data to proper locations only
 		for _, obj := range objects {

--- a/goon_test.go
+++ b/goon_test.go
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-package goon_test
+package goon
 
 import (
 	"reflect"
@@ -25,8 +25,6 @@ import (
 	"appengine/aetest"
 	"appengine/datastore"
 	"appengine/memcache"
-
-	"github.com/mjibson/goon"
 )
 
 func TestGoon(t *testing.T) {
@@ -35,7 +33,7 @@ func TestGoon(t *testing.T) {
 		t.Fatalf("Could not start aetest - %v", err)
 	}
 	defer c.Close()
-	n := goon.FromContext(c)
+	n := FromContext(c)
 
 	// key tests
 	noid := NoId{}
@@ -101,11 +99,11 @@ func TestGoon(t *testing.T) {
 	}
 	if err := n.GetMulti(es); err == nil {
 		t.Errorf("ds: expected error")
-	} else if !goon.NotFound(err, 0) {
+	} else if !NotFound(err, 0) {
 		t.Errorf("ds: not found error 0")
-	} else if !goon.NotFound(err, 1) {
+	} else if !NotFound(err, 1) {
 		t.Errorf("ds: not found error 1")
-	} else if goon.NotFound(err, 2) {
+	} else if NotFound(err, 2) {
 		t.Errorf("ds: not found error 2")
 	}
 	if keys, err := n.PutMulti(es); err != nil {
@@ -207,16 +205,21 @@ func TestVariance(t *testing.T) {
 		case "none":
 			// do nothing, use defaults already set
 		case "memcache":
-			g.MemcacheTimeout = 0
+			g.MemcacheGetTimeout = 0
+			g.MemcachePutTimeout = 0
 		case "datastore":
-			g.MemcacheTimeout = time.Millisecond * 2
+			g.MemcacheGetTimeout = time.Millisecond * 2
+			g.MemcachePutTimeout = time.Millisecond * 2
 			// can't timeout before memcache as memcache doesn't have a chance to return
 			// but the datastore request needs to actually timeout... These times work on my machine consistently
 			// I wasn't sure of a way to write this test any better - @mzimmerman
-			g.DatastoreTimeout = time.Millisecond * 2
+			g.DatastoreGetTimeout = time.Millisecond * 2
+			g.DatastorePutTimeout = time.Millisecond * 2
 		case "both":
-			g.MemcacheTimeout = 0
-			g.DatastoreTimeout = 0
+			g.MemcacheGetTimeout = 0
+			g.MemcachePutTimeout = 0
+			g.DatastoreGetTimeout = 0
+			g.DatastorePutTimeout = 0
 		}
 		objects := []*HasId{
 			&HasId{Id: 1, Name: "1"}, // stored in cache, memcache, and datastore
@@ -334,7 +337,7 @@ func TestRace(t *testing.T) {
 		t.Fatalf("Could not start aetest - %v", err)
 	}
 	defer c.Close()
-	g := goon.FromContext(c)
+	g := FromContext(c)
 
 	hasid := &HasId{Id: 1, Name: "Race"}
 	_, err = g.Put(hasid)
@@ -354,7 +357,7 @@ func TestPutGet(t *testing.T) {
 		t.Fatalf("Could not start aetest - %v", err)
 	}
 	defer c.Close()
-	g := goon.FromContext(c)
+	g := FromContext(c)
 
 	key, err := g.Put(&PutGet{ID: 12, Value: 15})
 	if err != nil {


### PR DESCRIPTION
At the moment, those values are only respected in GetMulti()

GetMulti() will now return the first set of values it can find while only making a Datastore request if the memcache request exceeds it's timeout value or fails to fetch all data

Added a test that has almost 100% coverage of the new code, however there's a race condition in that for one case, the Datastore request literally needs to timeout

This starts work on #15 but there's more to do