### PR TITLE
Application code should not be able to modify locacl cache except through Put/Get

### DIFF
--- a/goon.go
+++ b/goon.go
@@ -157,7 +157,7 @@ func (g *Goon) RunInTransaction(f func(tg *Goon) error, opts *datastore.Transact
 		g.cacheLock.Lock()
 		defer g.cacheLock.Unlock()
 		for k, v := range ng.toSet {
-			g.cache[k] = v
+			g.putMemoryKey(k, v)
 		}
 
 		for k := range ng.toDelete {
@@ -243,11 +243,22 @@ func (g *Goon) putMemoryMulti(src interface{}) {
 	}
 }
 
+// cache is already locked
+func (g *Goon) putMemoryKey(key string, src interface{}) {
+	if reflect.ValueOf(src).Kind() == reflect.Ptr { // since it's *struct, store a copy instead
+		n := reflect.New(reflect.ValueOf(src).Elem().Type())
+		n.Elem().Set(reflect.ValueOf(src).Elem())
+		g.cache[key] = n.Interface()
+	} else {
+		g.cache[key] = src
+	}
+}
+
 func (g *Goon) putMemory(src interface{}) {
 	key, _, _ := g.getStructKey(src)
 	g.cacheLock.Lock()
 	defer g.cacheLock.Unlock()
-	g.cache[memkey(key)] = src
+	g.putMemoryKey(memkey(key), src)
 }
 
 // FlushLocalCache clears the local memory cache.
@@ -349,6 +360,9 @@ func (g *Goon) GetMulti(dst interface{}) error {
 		m := memkey(key)
 		vi := v.Index(i)
 		if s, present := g.cache[m]; present {
+			if vi.Kind() == reflect.Interface {
+				vi = vi.Elem()
+			}
 			reflect.Indirect(vi).Set(reflect.Indirect(reflect.ValueOf(s)))
 		} else {
 			memkeys = append(memkeys, m)


### PR DESCRIPTION
In the current scheme, we're storing Put and Get objects in local cache, often struct pointers.  If an application does a Put/Get and then modifies a field in their struct for some local processing, the struct in local cache gets updated too (since it's the same one).  That wouldn't necessarily be a problem if the application then does a Put to save the changes, but that's not a requirement.  The application may want to use it for some temporary processing since the object was already allocated.  Temporary processing doesn't change the data in the datastore (and hence it shouldn't change it in goon either).  Temporary p

This change stores whatever the native format of the request is into cache.  That is, if the object is a struct pointer, a new allocation occurs, and the data is populated.  If the object is a struct, then assignment by value naturally stores a copy.

When retrieving from the local cache we also have to make a copy, otherwise any temporary calculations without a Put request would update the local cache as well.
