### PR TITLE
Interface encoding with robust memcache fails

### DIFF
--- a/goon_test.go
+++ b/goon_test.go
@@ -1927,7 +1927,7 @@ func init() {
 	gob.Register(&InterfaceImpl{})
 }
 
-func TestInterfaceTypes(t *testing.T) {
+func TestPropertyLoadSaver(t *testing.T) {
 	c, err := aetest.NewContext(nil)
 	if err != nil {
 		t.Fatalf("Could not start aetest - %v", err)


### PR DESCRIPTION
I mentioned in the robust memcache thread (#29) that the new code passed all my tests.  That was true at the time, but I've found that I apparently didn't have a very good test for one of my projects and use cases.  When updating goon for github.com/mzimmerman/sdzpinochle I found that this new robust memcache code doesn't properly encode interface types and this commit reflects a simplistic case of how I'm using goon in that project.

@xStrom A fix for the issue wasn't readily apparent to me so I'm hoping you'll know of one :)

Note that the change in serializeStructMetaData() may really just be masking a symptom, but it did remove a panic from this failing code.
