### PR TITLE
Add the ability to change how the Kind is determined on an Entity, on a per Goon instance basis.

### DIFF
--- a/query.go
+++ b/query.go
@@ -103,7 +103,7 @@ func (g *Goon) GetAll(q *datastore.Query, dst interface{}) ([]*datastore.Key, er
 			e = vi.Addr().Interface()
 		}
 
-		if err := setStructKey(e, k); err != nil {
+		if err := g.setStructKey(e, k); err != nil {
 			return nil, err
 		}
 
@@ -157,7 +157,7 @@ func (t *Iterator) Next(dst interface{}) (*datastore.Key, error) {
 
 	if dst != nil {
 		// Update the struct to have correct key info
-		setStructKey(dst, k)
+		t.g.setStructKey(dst, k)
 
 		if !t.g.inTransaction {
 			t.g.cacheLock.Lock()


### PR DESCRIPTION
This is through a function stored on Goon, the KindNameResolver.

This means if you want to do something globally, e.g. add a prefix to all Datastore Kinds, you can, without having to specify Kind values on each Entity instance.

For example:

``` go
func prefixKindName(src interface{}) string {
    return "myServiceName." + DefaultKindName(src)
}

g := FromContext(c)
g.KindNameResolver = prefixKindName

//now all Entities has the prefix of "myServiceName." when storing their data.

_, err := g.Put(thing)
```
