### PR TITLE
Correctly handle embedded unexported structs in Go 1.6.

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -177,7 +177,7 @@ func generateFieldInfoAndMetadata(t reflect.Type, namePrefix string, indexPrefix
 	numFields := t.NumField()
 	for i := 0; i < numFields; i++ {
 		tf := t.Field(i)
-		if tf.PkgPath != "" {
+		if tf.PkgPath != "" && !tf.Anonymous {
 			continue
 		}
 


### PR DESCRIPTION
[Go 1.6 will fix](https://github.com/golang/go/issues/12367) how unexported embedded structs are handled by the reflect package.

This patch makes sure goon will continue functioning properly with Go 1.6. The fix is also compatible with older versions, e.g. Go 1.4.2 which GAE currently uses.