### PR TITLE
clear the negative cache, even if key is IncompletedKey

### DIFF
--- a/goon.go
+++ b/goon.go
@@ -277,7 +277,9 @@ func (g *Goon) PutMulti(src interface{}) ([]*datastore.Key, error) {
 	if !g.inTransaction {
 		var memkeys []string
 		for _, key := range keys {
-			memkeys = append(memkeys, memkey(key))
+			if !key.Incomplete() {
+				memkeys = append(memkeys, memkey(key))
+			}
 		}
 		memcache.DeleteMulti(g.Context, memkeys)
 	}

--- a/goon_test.go
+++ b/goon_test.go
@@ -1079,6 +1079,59 @@ func TestNegativeCacheHit(t *testing.T) {
 	}
 }
 
+func TestNegativeCacheClear(t *testing.T) {
+	c, done, err := aetest.NewContext()
+	if err != nil {
+		t.Fatalf("Could not start aetest - %v", err)
+	}
+	defer done()
+	g := FromContext(c)
+
+	hid := &HasId{Name: "one"}
+	var id int64
+
+	puted := make(chan bool)
+	cached := make(chan bool)
+	ended := make(chan bool)
+
+	go func() {
+		err := g.RunInTransaction(func(tg *Goon) error {
+			tg.Put(hid)
+			id = hid.Id
+			puted <- true
+			<-cached
+			return nil
+		}, nil)
+		if err != nil {
+			t.Errorf("Unexpected error on RunInTransaction: %v", err)
+		}
+		ended <- true
+	}()
+
+	// simulate negative cache (yet commit)
+	{
+		<-puted
+		negative := &HasId{Id: id}
+		g.FlushLocalCache()
+		if err := g.Get(negative); err != datastore.ErrNoSuchEntity {
+			t.Errorf("Expected ErrNoSuchEntity, got %v", err)
+		}
+		cached <- true
+	}
+
+	{
+		<-ended
+		want := &HasId{Id: id}
+		g.FlushLocalCache()
+		if err := g.Get(want); err != nil {
+			t.Errorf("Unexpected error on get: %v", err)
+		}
+		if want.Name != hid.Name {
+			t.Errorf("Expected Get Entity got : %v", want)
+		}
+	}
+}
+
 func TestCaches(t *testing.T) {
 	c, done, err := aetest.NewContext()
 	if err != nil {


### PR DESCRIPTION
for some reason, it's possible that have cache.
I want to clear this cache in put operation.

I found following case.

Transactional task enqueuing is not support the order to execute datastore and taskqueue.
In the following code, we want to get `hid` in the task process.
But task is start before `ng.Put` in rare case.

```
err := g.RunInTransaction(func(ng *goon.Goon) error {
    if _, err := ng.Put(hid); err != nil {
        return err
    }
    t := &taskqueue.Task{Path: "/path/to/worker/" + hid.Id } 
    if _, err := taskqueue.Add(ctx, t, ""); err != nil {
        return err
    }
}, nil)

```