### PR TITLE
Allow swap memcache key algorithm

### DIFF
--- a/query.go
+++ b/query.go
@@ -109,7 +109,7 @@ func (g *Goon) GetAll(q *datastore.Query, dst interface{}) ([]*datastore.Key, er
 
 		if updateCache {
 			// Cache lock is handled before the for loop
-			g.cache[memkey(k)] = e
+			g.cache[MemcacheKey(k)] = e
 		}
 	}
 
@@ -161,7 +161,7 @@ func (t *Iterator) Next(dst interface{}) (*datastore.Key, error) {
 
 		if !t.g.inTransaction {
 			t.g.cacheLock.Lock()
-			t.g.cache[memkey(k)] = dst
+			t.g.cache[MemcacheKey(k)] = dst
 			t.g.cacheLock.Unlock()
 		}
 	}


### PR DESCRIPTION
I want to change memcache key generation algorithm.

## Motivation

I want to use this code.
This code makes free about remove property from kind schema.

```
func (entity *Foo) Load(p []datastore.Property) error {
    err := datastore.LoadStruct(entity, p)
    if fmerr, ok := err.(*datastore.ErrFieldMismatch); ok && fmerr != nil && fmerr.Reason == "no such struct field" {
        // ignore
    } else if err != nil {
        return err
    }

    // do something

    return nil
}
```

This is valid error handling. see https://github.com/golang/appengine/blob/926995697fa8241be2dc73eb318666e24f44ed51/datastore/load.go#L234-L236

Now, goon check undefined field. see https://github.com/mjibson/goon/blob/3618e6f56803ad77c732374326bb1e78f99097d4/entity.go#L617-L619
This is not good for me.

## My plan

I want to split memcache key per `version`.

```
verID := appengine.VersionID(c)
goon.MemcacheKey = func(k *datastore.Key) string {
	return "g2:" + verID + ":" + k.Encode()
}
```

This code solve my issue.

---

BTW, I think we need CI support. something... Circle CI or Travis CI.
