### PR TITLE
Implements IgnoreFieldMismatch option

### DIFF
--- a/goon.go
+++ b/goon.go
@@ -51,6 +51,9 @@ var (
 	// MemcacheGetTimeout is the amount of time to wait for all memcache Get
 	// requests.
 	MemcacheGetTimeout = time.Millisecond * 10
+
+	// Ignore ErrFieldMismatch
+	IgnoreFieldMismatch = false
 )
 
 // Goon holds the app engine context and the request memory cache.
@@ -523,7 +526,11 @@ func (g *Goon) GetMulti(dst interface{}) error {
 					return
 				}
 				for i, idx := range dixs[lo:hi] {
-					if merr[i] == nil {
+					isFieldMismatch := false
+					if _, ok := merr[i].(*datastore.ErrFieldMismatch); ok {
+						isFieldMismatch = true
+					}
+					if merr[i] == nil || isFieldMismatch && IgnoreFieldMismatch {
 						toCache = append(toCache, dsdst[lo+i])
 						exists = append(exists, 1)
 					} else {


### PR DESCRIPTION
This PR implements IgnoreFieldMismatch which is discussed on the following comment.

>  I think I would still like to make that easier, possibly by just silently ignoring the field mismatch errors, at all layers. Silent, because how often do people really load the wrong entity? I've certainly never encountered that. What I have encountered a lot is deprecated properties that I would just like to remove and not have to worry about any error handling at all.
https://github.com/mjibson/goon/pull/59

goon ignores ErrFieldMimatch if IgnoreFieldMismatch is True. I think this option works well when we remove some deprecated fields.
 