### PR TITLE
Add IgnoreFieldMismatch option to ignore ErrFieldMismatch

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -603,6 +603,7 @@ func deserializeStruct(dst interface{}, b []byte) error {
 	defer freeSerializationDecoder(sd)
 	structHistory := make(map[string]map[string]bool, 8)
 	fieldMap, _ := getFieldInfoAndMetadata(t)
+	var notFoundField string
 
 	for _, metaData := range smd.metaDatas {
 		fieldName, slice, zeroValue := metaData, false, false
@@ -613,16 +614,22 @@ func deserializeStruct(dst interface{}, b []byte) error {
 		}
 		nameParts := strings.Split(fieldName, ".")
 
-		fi, ok := fieldMap[fieldName]
-		if !ok {
-			return fmt.Errorf("goon: Could not find field %v", fieldName)
-		}
-
-		if err := deserializeStructInternal(sd.dec, fi, fieldName, nameParts, slice, zeroValue, structHistory, v, t); err != nil {
-			return err
+		if fi, ok := fieldMap[fieldName]; ok {
+			if err := deserializeStructInternal(sd.dec, fi, fieldName, nameParts, slice, zeroValue, structHistory, v, t); err != nil {
+				return err
+			}
+		} else {
+			notFoundField = fieldName
 		}
 	}
 
+	if notFoundField != "" {
+		return &datastore.ErrFieldMismatch{
+			StructType: t,
+			FieldName:  notFoundField,
+			Reason:     "no such struct field",
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## The essence of this change is to easily support removing struct fields.

```go
// Initial struct which has been used to save data
type Foo struct {
    Id  int64 `datastore:"-" goon:"id"`
    One int64 `datastore:"one,noindex"`
    Two int64 `datastore:"two,noindex"`
}

// Updated struct which can be used to load data without errors
type Foo struct {
    Id  int64 `datastore:"-" goon:"id"`
    One int64 `datastore:"one,noindex"`
    // No field "two", which will be silently forgotten
}
```

This is supported by the full API. `Get`, `GetMulti`, `GetAll`, `iterator.Next` all behave correctly.

The support is there for both the datastore & the memcache layer. No support for local cache, because most people will restart their instance when making struct type changes. Those who don't can use `FlushLocalCache`.

The behavior itself is configurable by the new `IgnoreFieldMismatch` option, which defaults to `true`.

## Choosing the default

The best case for defaulting to `false` that I've come up with is protection against developer mistakes. The scenario being that a clumsy developer accidentally modifies a struct field name. (The field must not have a datastore tag redefining the name, or the accident must be a modification of the tag instead.) With the setting set to `true` there won't be any errors and any data previously saved into that field will gradually disappear as entities get resaved.

However there are a number of best practices that will prevent this being an issue.
1) The developer will notice the mistake while comitting to source control.
2) Others will notice during code review.
3) Someone will notice after the code has been deployed to the development/test server.

Thus worrying about these accidental changes is mostly just worrying about developers who are also ignoring the above best practices.

The motivation for defaulting to `true` is ease of use & *Everything Just Works*™. This whole library is already about convenience & magic. We encapsulate `Context` so it doesn't have to be passed around, we support big batches by splitting up the requests, we do intelligent caching. In my view supporting the removal of struct fields without any extra work falls exacltly in line with the spirit of this library. Thus I have defaulted `IgnoreFieldMismatch` to `true`.

If anyone thinks `true` is a bad idea, I think now is a great time to make that case.

## Attributions

Thanks to @vvakame for [bringing it to my attention](https://github.com/mjibson/goon/pull/59) that actual goon users would like to ignore `ErrFieldMismatch`. That PR gave a quick solution with definable memcache key prefixes. Now our memcache layer works like the datastore, in that we return `ErrFieldMismatch` which can be ignored, because we don't stop work due to it. (If option is `false`, otherwise we don't even return the error.)

Thanks to @yuichi1004 for doing [an initial implementation](https://github.com/mjibson/goon/pull/66) for the datastore layer for some API functions. I used this work as a starting point for what I've now submitted here.