### PR TITLE
Support PropertyLoadSaver Interface

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -423,10 +423,10 @@ func serializeStruct(src interface{}) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		for _, prop := range props {
-			v := reflect.ValueOf(prop.Value)
+		for i := 0; i < len(props); i++ {
+			v := reflect.ValueOf(props[i].Value)
 			if v.Kind() == reflect.Ptr && v.IsNil() {
-				prop.Value = nilType{}
+				props[i].Value = nilType{}
 			}
 		}
 		if err := se.enc.Encode(props); err != nil {
@@ -681,6 +681,12 @@ func deserializeStruct(dst interface{}, b []byte) error {
 		var props []datastore.Property
 		if err := sd.dec.Decode(&props); err != nil {
 			return errCacheFetchFailed
+		}
+		for i := 0; i < len(props); i++ {
+			nilVal := nilType{}
+			if props[i].Value == nilVal {
+				props[i].Value = nil
+			}
 		}
 		if hasPLS {
 			if err := pls.Load(props); err != nil {

--- a/entity.go
+++ b/entity.go
@@ -132,6 +132,23 @@ func init() {
 	//       * The usage is removed during a code update
 	//    b) Register a same type as us, but in an inconsistent order between multiple executions
 	freeSerializationDecoder(getSerializationDecoder([]byte{}))
+
+	// register gob types
+	gob.Register(seBoot.v01)
+	gob.Register(seBoot.v02)
+	gob.Register(seBoot.v03)
+	gob.Register(seBoot.v04)
+	gob.Register(seBoot.v05)
+	gob.Register(seBoot.v06)
+	gob.Register(seBoot.v07)
+	gob.Register(seBoot.v08)
+	gob.Register(seBoot.v09)
+	gob.Register(seBoot.v10)
+	gob.Register(seBoot.v11)
+	gob.Register(seBoot.v12)
+	gob.Register(seBoot.v13)
+	gob.Register(seBoot.v14)
+	gob.Register(seBoot.v15)
 }
 
 // getFieldInfoAndMetadata returns metadata about a struct. Its main purpose is to cut down

--- a/entity.go
+++ b/entity.go
@@ -86,6 +86,8 @@ type nilType struct {
 	GoonNilValue string
 }
 
+var nilValue = nilType{}
+
 type serializationReader struct {
 	r *bytes.Reader
 }
@@ -156,7 +158,7 @@ func init() {
 	gob.Register(seBoot.v13)
 	gob.Register(seBoot.v14)
 	gob.Register(seBoot.v15)
-	gob.Register(nilType{})
+	gob.Register(nilValue)
 }
 
 // getFieldInfoAndMetadata returns metadata about a struct. Its main purpose is to cut down
@@ -426,7 +428,7 @@ func serializeStruct(src interface{}) ([]byte, error) {
 		for i := 0; i < len(props); i++ {
 			v := reflect.ValueOf(props[i].Value)
 			if v.Kind() == reflect.Ptr && v.IsNil() {
-				props[i].Value = nilType{}
+				props[i].Value = nilValue
 			}
 		}
 		if err := se.enc.Encode(props); err != nil {
@@ -683,8 +685,7 @@ func deserializeStruct(dst interface{}, b []byte) error {
 			return errCacheFetchFailed
 		}
 		for i := 0; i < len(props); i++ {
-			nilVal := nilType{}
-			if props[i].Value == nilVal {
+			if props[i].Value == nilValue {
 				props[i].Value = nil
 			}
 		}

--- a/entity.go
+++ b/entity.go
@@ -429,6 +429,9 @@ func serializeStruct(src interface{}) ([]byte, error) {
 				prop.Value = nilType{}
 			}
 		}
+		if err := se.enc.Encode(props); err != nil {
+			return nil, fmt.Errorf("goon: Failed to encode PropertyList - %v", err)
+		}
 		return se.buf.Bytes(), nil
 	} else {
 		smd := &structMetaData{metaDatas: make([]string, 0, 16)}

--- a/entity.go
+++ b/entity.go
@@ -420,7 +420,7 @@ func serializeStruct(src interface{}) ([]byte, error) {
 	defer freeSerializationEncoder(se)
 
 	if ls, ok := src.(datastore.PropertyLoadSaver); ok {
-		se.buf.Write([]byte{serializationStatePropertyList})
+		se.buf.WriteByte(serializationStatePropertyList)
 		props, err := ls.Save()
 		if err != nil {
 			return nil, err

--- a/goon.go
+++ b/goon.go
@@ -492,18 +492,19 @@ func (g *Goon) GetMulti(dst interface{}) error {
 			if v.Index(mixs[i]).Kind() == reflect.Struct {
 				d = v.Index(mixs[i]).Addr().Interface()
 			}
-			fetched := true
+			fetched := false
 			if s, present := memvalues[m]; present {
 				err := deserializeStruct(d, s.Value)
 				if err == nil || (IgnoreFieldMismatch && errFieldMismatch(err)) {
 					g.putMemory(d)
+					fetched = true
 				} else if err == datastore.ErrNoSuchEntity || errFieldMismatch(err) {
 					anyErr = true // this flag tells GetMulti to return multiErr later
 					multiErr[mixs[i]] = err
+					fetched = true // success to fetch negative cache. no need to fallback to datastore
 				} else if err == errCacheFetchFailed {
-					fetched = false
+					// NOP
 				} else {
-					fetched = false
 					g.error(err)
 					return err
 				}

--- a/goon.go
+++ b/goon.go
@@ -473,6 +473,7 @@ func (g *Goon) GetMulti(dst interface{}) error {
 			if v.Index(mixs[i]).Kind() == reflect.Struct {
 				d = v.Index(mixs[i]).Addr().Interface()
 			}
+			fetched := true
 			if s, present := memvalues[m]; present {
 				err := deserializeStruct(d, s.Value)
 				if err == nil || (IgnoreFieldMismatch && errFieldMismatch(err)) {
@@ -480,11 +481,15 @@ func (g *Goon) GetMulti(dst interface{}) error {
 				} else if err == datastore.ErrNoSuchEntity || errFieldMismatch(err) {
 					anyErr = true // this flag tells GetMulti to return multiErr later
 					multiErr[mixs[i]] = err
+				} else if err == errCacheFetchFailed {
+					fetched = false
 				} else {
+					fetched = false
 					g.error(err)
 					return err
 				}
-			} else {
+			}
+			if !fetched {
 				dskeys = append(dskeys, keys[mixs[i]])
 				dsdst = append(dsdst, d)
 				dixs = append(dixs, mixs[i])

--- a/goon.go
+++ b/goon.go
@@ -75,7 +75,7 @@ type Goon struct {
 // MemcacheKey returns key string of Memcache.
 var MemcacheKey = func(k *datastore.Key) string {
 	// Versioning, so that incompatible changes to the cache system won't cause problems
-	return "g2:" + k.Encode()
+	return "g3:" + k.Encode()
 }
 
 // NewGoon creates a new Goon object from the given request.

--- a/goon_test.go
+++ b/goon_test.go
@@ -948,7 +948,7 @@ func TestMigration(t *testing.T) {
 	}
 
 	// Run migration tests with both IgnoreFieldMismatch on & off
-	for _, IgnoreFieldMismatch := range []bool{true, false} {
+	for _, IgnoreFieldMismatch = range []bool{true, false} {
 		testcase := []struct {
 			name string
 			src  MigrationEntity

--- a/goon_test.go
+++ b/goon_test.go
@@ -948,36 +948,36 @@ func TestMigration(t *testing.T) {
 	}
 
 	// Run migration tests with both IgnoreFieldMismatch on & off
-	testcase := []struct {
-		name string
-		src  MigrationEntity
-		dst  func() MigrationEntity
-	}{
-		{
-			name: "NormalCache -> NormalCache",
-			src:  &MigrationA{Parent: parentKey, Id: 1},
-			dst:  func() MigrationEntity { return &MigrationB{Parent: parentKey, Identification: 1} },
-		},
-		{
-			// struct can fetch PropertyListCache
-			name: "PropertyListCache -> NormalCache",
-			src:  &MigrationPlsA{Parent: parentKey, Id: 1},
-			dst:  func() MigrationEntity { return &MigrationB{Parent: parentKey, Identification: 1} },
-		},
-		{
-			name: "PropertyListCache -> PropertyListCache",
-			src:  &MigrationPlsA{Parent: parentKey, Id: 1},
-			dst:  func() MigrationEntity { return &MigrationPlsB{Parent: parentKey, Identification: 1} },
-		},
-		{
-			// PropertyLoadSaver should not fetch NormalCache but simply falls back to datastore
-			name: "NormalCache -> PropertyListCache",
-			src:  &MigrationA{Parent: parentKey, Id: 1},
-			dst:  func() MigrationEntity { return &MigrationPlsB{Parent: parentKey, Identification: 1} },
-		},
-	}
-	for _, tt := range testcase {
-		for _, IgnoreFieldMismatch = range []bool{true, false} {
+	for _, IgnoreFieldMismatch := range []bool{true, false} {
+		testcase := []struct {
+			name string
+			src  MigrationEntity
+			dst  MigrationEntity
+		}{
+			{
+				name: "NormalCache -> NormalCache",
+				src:  &MigrationA{Parent: parentKey, Id: 1},
+				dst:  &MigrationB{Parent: parentKey, Identification: 1},
+			},
+			{
+				// struct can fetch PropertyListCache
+				name: "PropertyListCache -> NormalCache",
+				src:  &MigrationPlsA{Parent: parentKey, Id: 1},
+				dst:  &MigrationB{Parent: parentKey, Identification: 1},
+			},
+			{
+				name: "PropertyListCache -> PropertyListCache",
+				src:  &MigrationPlsA{Parent: parentKey, Id: 1},
+				dst:  &MigrationPlsB{Parent: parentKey, Identification: 1},
+			},
+			{
+				// PropertyLoadSaver should not fetch NormalCache but simply falls back to datastore
+				name: "NormalCache -> PropertyListCache",
+				src:  &MigrationA{Parent: parentKey, Id: 1},
+				dst:  &MigrationPlsB{Parent: parentKey, Identification: 1},
+			},
+		}
+		for _, tt := range testcase {
 			// Clear all the caches
 			g.FlushLocalCache()
 			memcache.Flush(c)
@@ -992,9 +992,8 @@ func TestMigration(t *testing.T) {
 
 			// Test whether memcache supports migration
 			var fetched MigrationEntity
-			dst := tt.dst()
 			debugInfo := fmt.Sprintf("%s - field mismatch: %v - MC", tt.name, IgnoreFieldMismatch)
-			fetched = verifyMigration(t, g, tt.src, dst, migrationMethodGet, debugInfo)
+			fetched = verifyMigration(t, g, tt.src, tt.dst, migrationMethodGet, debugInfo)
 			checkMigrationResult(t, g, tt.src, fetched, debugInfo)
 
 			// Test whether datastore supports migration
@@ -1008,13 +1007,13 @@ func TestMigration(t *testing.T) {
 					debugInfo := fmt.Sprintf("%s DS-%v-%v-%v", tt.name, tx, method, IgnoreFieldMismatch)
 					if tx == 1 {
 						if err := g.RunInTransaction(func(tg *Goon) error {
-							fetched = verifyMigration(t, tg, tt.src, dst, method, debugInfo)
+							fetched = verifyMigration(t, tg, tt.src, tt.dst, method, debugInfo)
 							return nil
 						}, &datastore.TransactionOptions{XG: false}); err != nil {
 							t.Errorf("Unexpected error with TXN - %v", err)
 						}
 					} else {
-						fetched = verifyMigration(t, g, tt.src, dst, method, debugInfo)
+						fetched = verifyMigration(t, g, tt.src, tt.dst, method, debugInfo)
 					}
 					checkMigrationResult(t, g, tt.src, fetched, debugInfo)
 				}


### PR DESCRIPTION
# Introduction

This PR supports PropertyLoadSaver interface.

https://cloud.google.com/appengine/docs/standard/go/datastore/reference#hdr-The_PropertyLoadSaver_Interface

This PR should resolve #53.

# Strategy

* Define serializationStatePropertyList as new cache type
  - PropertyLists are cached with serializationStatePropertyList, while others are cached with serializationStateNormal
  - This strategy simplifies the implementation than maintaining compatibility of normal cache to PropertyLoadSaver interface
  - I think most people use one of normal struct or PropertyLoadSaver interface so this works on most of the use cases
* Support fetching different cache type if possible, fallback to datastore if not
  - This strategy supports most of the case with cache efficiency
  - This strategy avoids error even if fetching different cache type is not supported

Please take a look at the code. Any comments, improvements, proposal of the different approach are welcome.