### PR TITLE
Properly discard unused struct fields

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -619,6 +619,7 @@ func deserializeStruct(dst interface{}, b []byte) error {
 				return err
 			}
 		} else {
+			sd.dec.Decode(nil) // Discard the value
 			notFoundField = fieldName
 		}
 	}


### PR DESCRIPTION
When properties are removed from the middle of a struct, then the memcache layer will attempt to set the next property to this removed property's value.

This PR makes sure we discard memcache values for unused properties.