### PR TITLE
Add support for all datastore supported data types.

### DIFF
--- a/goon.go
+++ b/goon.go
@@ -75,7 +75,7 @@ type Goon struct {
 // MemcacheKey returns key string of Memcache.
 var MemcacheKey = func(k *datastore.Key) string {
 	// Versioning, so that incompatible changes to the cache system won't cause problems
-	return "g3:" + k.Encode()
+	return "g4:" + k.Encode()
 }
 
 // NewGoon creates a new Goon object from the given request.


### PR DESCRIPTION
## Clean up and improve some of the tests
I made the giant test data struct `ivItem` a more straightforward implementation of all the [officially supported datastore types](https://cloud.google.com/appengine/docs/standard/go/datastore/reference), plus some undocumented but still working types like custom slice types. I also rewrote the `ivItem` cloning mechanism so it's more easily maintainable, plus added a test to actually confirm the cloning works.

## Client-facing changes
- There's now support for all the datastore supported types in the PropertyLoadSave implementation
- The regular old struct Get/Put system also got a few updates:
  - `[]Foo` where `type Foo []byte` is now supported
  - `Foo` where `type Foo []T` where `T` is one of the supported slice element types 