### PR TITLE
Migrate to the standard library context.

### DIFF
--- a/goon.go
+++ b/goon.go
@@ -17,6 +17,7 @@
 package goon
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -25,7 +26,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 	"google.golang.org/appengine/log"

--- a/goon_test.go
+++ b/goon_test.go
@@ -18,6 +18,7 @@ package goon
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -27,7 +28,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/aetest"
 	"google.golang.org/appengine/datastore"


### PR DESCRIPTION
The `golang.org/x/net/context` package has been superseded by the standard library `context` package since Go 1.7. App Engine [deprecated support for Go 1.6](https://cloud.google.com/appengine/docs/standard/go/release-notes) on August 1, 2018 and new Go 1.6 based deployments stopped being accepted on November 1, 2018. This means that we can now remove pre-1.7 support from goon and migrate to the standard library `context`.