### PR TITLE
Restore the memcache timeout test.

### DIFF
--- a/goon_test.go
+++ b/goon_test.go
@@ -1360,6 +1360,12 @@ func TestMigration(t *testing.T) {
 		t.Fatalf("Could not start aetest - %v", err)
 	}
 	defer done()
+
+	origIFM := IgnoreFieldMismatch
+	defer func() {
+		IgnoreFieldMismatch = origIFM
+	}()
+
 	g := FromContext(c)
 
 	// Create & save an entity with the original structure
@@ -2457,66 +2463,6 @@ type PutGet struct {
 	Value int32
 }
 
-// Commenting out for issue https://code.google.com/p/googleappengine/issues/detail?id=10493
-//func TestMemcachePutTimeout(t *testing.T) {
-//	c, done, err := aetest.NewContext()
-//	if err != nil {
-//		t.Fatalf("Could not start aetest - %v", err)
-//	}
-//	defer done()
-//	g := FromContext(c)
-//	MemcachePutTimeoutSmall = time.Second
-//	// put a HasId resource, then test pulling it from memory, memcache, and datastore
-//	hi := &HasId{Name: "hasid"} // no id given, should be automatically created by the datastore
-//	if _, err := g.Put(hi); err != nil {
-//		t.Errorf("put: unexpected error - %v", err)
-//	}
-
-//	MemcachePutTimeoutSmall = 0
-//	MemcacheGetTimeout = 0
-//	if err := g.putMemcache([]interface{}{hi}); !appengine.IsTimeoutError(err) {
-//		t.Errorf("Request should timeout - err = %v", err)
-//	}
-//	MemcachePutTimeoutSmall = time.Second
-//	MemcachePutTimeoutThreshold = 0
-//	MemcachePutTimeoutLarge = 0
-//	if err := g.putMemcache([]interface{}{hi}); !appengine.IsTimeoutError(err) {
-//		t.Errorf("Request should timeout - err = %v", err)
-//	}
-
-//	MemcachePutTimeoutLarge = time.Second
-//	if err := g.putMemcache([]interface{}{hi}); err != nil {
-//		t.Errorf("putMemcache: unexpected error - %v", err)
-//	}
-
-//	g.FlushLocalCache()
-//	memcache.Flush(c)
-//	// time out Get
-//	MemcacheGetTimeout = 0
-//	// time out Put too
-//	MemcachePutTimeoutSmall = 0
-//	MemcachePutTimeoutThreshold = 0
-//	MemcachePutTimeoutLarge = 0
-//	hiResult := &HasId{Id: hi.Id}
-//	if err := g.Get(hiResult); err != nil {
-//		t.Errorf("Request should not timeout cause we'll fetch from the datastore but got error  %v", err)
-//		// Put timing out should also error, but it won't be returned here, just logged
-//	}
-//	if !reflect.DeepEqual(hi, hiResult) {
-//		t.Errorf("Fetched object isn't accurate - want %v, fetched %v", hi, hiResult)
-//	}
-
-//	hiResult = &HasId{Id: hi.Id}
-//	g.FlushLocalCache()
-//	MemcacheGetTimeout = time.Second
-//	if err := g.Get(hiResult); err != nil {
-//		t.Errorf("Request should not timeout cause we'll fetch from memcache successfully but got error %v", err)
-//	}
-//	if !reflect.DeepEqual(hi, hiResult) {
-//		t.Errorf("Fetched object isn't accurate - want %v, fetched %v", hi, hiResult)
-//	}
-//}
-
 // This test won't fail but if run with -race flag, it will show known race conditions
 // Using multiple goroutines per http request is recommended here:
 // http://talks.golang.org/2013/highperf.slide#22
@@ -2926,6 +2872,87 @@ func TestEmbeddedStruct(t *testing.T) {
 		if gcs.y != 0 {
 			t.Fatalf("#%v - Expected - %v, got %v", i, 0, gcs.y)
 		}
+	}
+}
+
+func TestMemcachePutTimeout(t *testing.T) {
+	c, done, err := aetest.NewContext()
+	if err != nil {
+		t.Fatalf("Could not start aetest - %v", err)
+	}
+	defer done()
+
+	origMPTS := MemcachePutTimeoutSmall
+	origMPTL := MemcachePutTimeoutLarge
+	origMPTT := MemcachePutTimeoutThreshold
+	origMGT := MemcacheGetTimeout
+	defer func() {
+		MemcachePutTimeoutSmall = origMPTS
+		MemcachePutTimeoutLarge = origMPTL
+		MemcachePutTimeoutThreshold = origMPTT
+		MemcacheGetTimeout = origMGT
+	}()
+
+	g := FromContext(c)
+	MemcachePutTimeoutSmall = time.Second
+	// put a HasId resource, then test pulling it from memory, memcache, and datastore
+	hi := &HasId{Name: "hasid"} // no id given, should be automatically created by the datastore
+	if _, err := g.Put(hi); err != nil {
+		t.Fatalf("put: unexpected error - %v", err)
+	}
+
+	// Generate the cache entry
+	props, err := datastore.SaveStruct(hi)
+	if err != nil {
+		t.Fatalf("Unexpected error on SaveStruct: %v", err)
+	}
+	ce := cacheEntry{
+		key:   g.Key(hi),
+		props: props,
+	}
+	ces := []cacheEntry{ce}
+
+	MemcachePutTimeoutSmall = 0
+	if err := g.putMemcache(ces); !appengine.IsTimeoutError(err) {
+		t.Fatalf("Request should timeout - err = %v", err)
+	}
+	MemcachePutTimeoutSmall = time.Second
+	MemcachePutTimeoutThreshold = 0
+	MemcachePutTimeoutLarge = 0
+	if err := g.putMemcache(ces); !appengine.IsTimeoutError(err) {
+		t.Fatalf("Request should timeout - err = %v", err)
+	}
+
+	MemcachePutTimeoutLarge = time.Second
+	if err := g.putMemcache(ces); err != nil {
+		t.Fatalf("putMemcache: unexpected error - %v", err)
+	}
+
+	g.FlushLocalCache()
+	memcache.Flush(c)
+	// time out Get
+	MemcacheGetTimeout = 0
+	// time out Put too
+	MemcachePutTimeoutSmall = 0
+	MemcachePutTimeoutThreshold = 0
+	MemcachePutTimeoutLarge = 0
+	hiResult := &HasId{Id: hi.Id}
+	if err := g.Get(hiResult); err != nil {
+		t.Fatalf("Request should not timeout cause we'll fetch from the datastore but got error  %v", err)
+		// Put timing out should also error, but it won't be returned here, just logged
+	}
+	if !reflect.DeepEqual(hi, hiResult) {
+		t.Fatalf("Fetched object isn't accurate\n%s", getDiff(hi, hiResult, "hi", "hiResult"))
+	}
+
+	hiResult = &HasId{Id: hi.Id}
+	g.FlushLocalCache()
+	MemcacheGetTimeout = time.Second
+	if err := g.Get(hiResult); err != nil {
+		t.Fatalf("Request should not timeout cause we'll fetch from memcache successfully but got error %v", err)
+	}
+	if !reflect.DeepEqual(hi, hiResult) {
+		t.Fatalf("Fetched object isn't accurate\n%s", getDiff(hi, hiResult, "hi", "hiResult"))
 	}
 }
 


### PR DESCRIPTION
As the App Engine Go SDK issues [35896942](https://issuetracker.google.com/issues/35896942) & [35897435](https://issuetracker.google.com/issues/35897435) conclude, `goapp test` supports timeouts now. This means we can bring back the memcache timeout test we had previously commented out.