### PR TITLE
Add the AUTHORS file.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+# This is the list of Goon authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history in source control.
+Matt Jibson <matt.jibson@gmail.com>
+Kaur Kuut <strom@nevermore.ee>
+Matthew Zimmerman <mzimmerman@gmail.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012 Matt Jibson <matt.jibson@gmail.com>
+Copyright (c) 2012 The Goon Authors
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/entity.go
+++ b/entity.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 Matt Jibson <matt.jibson@gmail.com>
+ * Copyright (c) 2012 The Goon Authors
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/goon.go
+++ b/goon.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 Matt Jibson <matt.jibson@gmail.com>
+ * Copyright (c) 2012 The Goon Authors
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/goon_test.go
+++ b/goon_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Matt Jibson <matt.jibson@gmail.com>
+ * Copyright (c) 2012 The Goon Authors
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/query.go
+++ b/query.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 Matt Jibson <matt.jibson@gmail.com>
+ * Copyright (c) 2012 The Goon Authors
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
This PR creates an AUTHORS file to list major contributors. The AUTHORS file is based on [Google's guidelines](https://opensource.google.com/docs/releasing/authors/). The motivation here is preparation for potential new files where the previous copyright header wouldn't make too much sense. The AUTHORS file makes the whole thing more universally applicable.