### PR TITLE
Update the memcache timeout system

### DIFF
--- a/goon_test.go
+++ b/goon_test.go
@@ -38,7 +38,6 @@ import (
 func init() {
 	// The SDK emulators are extremely slow, so we can't use production timeouts
 	MemcachePutTimeoutSmall = 10 * time.Second
-	MemcachePutTimeoutLarge = 10 * time.Second
 	MemcacheGetTimeout = 10 * time.Second
 	// Make sure to propagate all errors for better testing
 	propagateMemcachePutError = true
@@ -3008,12 +3007,8 @@ func TestMemcachePutTimeout(t *testing.T) {
 	cis := []*cacheItem{ci}
 
 	MemcachePutTimeoutSmall = 0
-	if err := g.putMemcache(cis); !appengine.IsTimeoutError(err) {
-		t.Fatalf("Request should timeout - err = %v", err)
-	}
-	MemcachePutTimeoutSmall = time.Second
-	MemcachePutTimeoutThreshold = 0
 	MemcachePutTimeoutLarge = 0
+	MemcachePutTimeoutThreshold = 1
 	if err := g.putMemcache(cis); !appengine.IsTimeoutError(err) {
 		t.Fatalf("Request should timeout - err = %v", err)
 	}
@@ -3029,7 +3024,7 @@ func TestMemcachePutTimeout(t *testing.T) {
 	MemcacheGetTimeout = 0
 	// time out Put too
 	MemcachePutTimeoutSmall = 0
-	MemcachePutTimeoutThreshold = 0
+	MemcachePutTimeoutThreshold = 1
 	MemcachePutTimeoutLarge = 0
 	hiResult := &HasId{Id: hi.Id}
 	if err := g.Get(hiResult); err != nil {


### PR DESCRIPTION
The previous memcache timeouts were decided in 2014. Things have changed a bit since then. Most importantly the batch RPC limits have been increased by 3x. This means that if goon tries to fetch a giant batch of items from memcache, the old short timeouts would always be hit.

The general rules for timeout determining seem to be the same today as they were 5 years ago. However we now need to support a wider range of payload sizes.

The `memcache.GetMulti` and `memcache.PutMulti` calls seem to behave almost identically in terms of duration nowadays. A simple calculation of 1 millisecond per 20 KiB of payload seems to cover all median cases, and even a lot of slow cases.

For backwards compatibility reasons I didn't write a completely new way to configure the timeouts. Instead I retrofitted the new system to the old configuration variables. The meaning of the timeout variables has changed, but not insanely so. Most importantly, if someone is using custom timeout values, then the timeout behavior may be more lenient now but rarely more strict.