### PR TITLE
Add Go modules support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/mjibson/goon
+
+go 1.9
+
+require (
+	github.com/golang/protobuf v1.2.0
+	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
+	google.golang.org/appengine v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f h1:R423Cnkcp5JABoeemiGEPlt9tHXFfw5kvc0yqlxRPWo=
+golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225 h1:kNX+jCowfMYzvlSvJu5pQWEmyWFrBXJ3PBy10xKMXK8=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+google.golang.org/appengine v1.3.0 h1:FBSsiFRMz3LBeXIomRnVzrQwSDj4ibvcRexLG0LZGQk=
+google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/goon_test.go
+++ b/goon_test.go
@@ -3075,7 +3075,7 @@ func TestChangeMemcacheKey(t *testing.T) {
 	defer func() {
 		MemcacheKey = originalMemcacheKey
 	}()
-	verID := appengine.VersionID(c)
+	verID := "some-version"
 	MemcacheKey = func(k *datastore.Key) string {
 		return "custom:" + verID + ":" + k.Encode()
 	}


### PR DESCRIPTION
## Overview
This PR lays the groundwork for our first [Go modules](https://github.com/golang/go/wiki/Modules) compatible release.

Although we have a historic v1 already, using the ancient `appengine` package, and thus have been on v2 for years. We're going to be rewriting some history to make things as compatible as possible.

App Engine still supports new deployments with Go 1.9 and goon will continue to be supported on Go 1.9 with zero modifications.

## The near future
* The old v1 is going to be renamed to v0 and will be available on the [v0 branch](https://github.com/mjibson/goon/tree/v0).
* The old v2 on the master branch will be renamed v1 and will continue to live on the master branch.
* If we choose to release new major versions (e.g. v2/v3), they will live on dedicated branches with master being untouched and staying on the new v1.

This means that `import "github.com/mjibson/goon"` will continue to point to the same API in both old module-unaware Go 1.9 and also in new module aware Go versions.

## The distant future
Once the following three conditions are met:
* Google stops allowing new Go 1.9 deployments to App Engine.
* The community has migrated to module based imports (Modules on by default expected by Go 1.14).
* Goon has a v2 or higher.

... then the following will happen:
* The master branch will move to a dedicated legacy v1 branch.
* Whatever is the newest goon version (e.g. v3) will move to the master branch.

