### PR TITLE
Fix the Go module directive for version 2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You must choose the goon major version based on which App Engine library you are
 
 | App Engine Go library            | Include in your project     | Correct goon version                                                   |
 |----------------------------------|-----------------------------|------------------------------------------------------------------------|
-| `google.golang.org/appengine/v2` |`github.com/mjibson/goon/v2` | [goon v2.0.0](https://github.com/mjibson/goon/releases/tag/v2.0.0)     |
+| `google.golang.org/appengine/v2` |`github.com/mjibson/goon/v2` | [goon v2.0.1](https://github.com/mjibson/goon/releases/tag/v2.0.1)     |
 | `google.golang.org/appengine`    |`github.com/mjibson/goon`    | [goon v1.1.0](https://github.com/mjibson/goon/releases/tag/v1.1.0)     |
 | `appengine`                      |`github.com/mjibson/goon`    | [goon v0.9.0](https://github.com/mjibson/goon/releases/tag/v0.9.0)     |
 | `cloud.google.com/go`            |N/A                          | Not supported ([issue #74](https://github.com/mjibson/goon/issues/74)) |

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mjibson/goon
+module github.com/mjibson/goon/v2
 
 go 1.12
 


### PR DESCRIPTION
This PR adds the major version to the end of the module path in the module directive in `go.mod`.