### PR TITLE
Next Method in query causes panic

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -97,17 +97,17 @@ func deserializeEntityHeader(header uint32) (propCount, flags int) {
 }
 
 // The valid datastore.Property.Value types are:
-//    - int64
-//    - bool
-//    - string
-//    - float64
-//    - datastore.ByteString
-//    - *datastore.Key
-//    - time.Time
-//    - appengine.BlobKey
-//    - appengine.GeoPoint
-//    - []byte (up to 1 megabyte in length)
-//    - *Entity (representing a nested struct)
+//   - int64
+//   - bool
+//   - string
+//   - float64
+//   - datastore.ByteString
+//   - *datastore.Key
+//   - time.Time
+//   - appengine.BlobKey
+//   - appengine.GeoPoint
+//   - []byte (up to 1 megabyte in length)
+//   - *Entity (representing a nested struct)
 const (
 	propTypeNone       = 0
 	propTypeInt64      = 1
@@ -178,6 +178,9 @@ func fromUnixMicro(t int64) time.Time {
 }
 
 func isIndexValue(p *datastore.Property) bool {
+	if p.Value == nil {
+		return false
+	}
 	v := reflect.ValueOf(p.Value)
 	return v.Type().String() == "datastore.indexValue"
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Kazzz/goon/v2
+module github.com/mjibson/goon/v2
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mjibson/goon/v2
+module github.com/Kazzz/goon/v2
 
 go 1.12
 


### PR DESCRIPTION
After running the query, when executing the iterator's Next method, if the loaded entity's property[0] value is nil, the Next method panics.

This issue is caused by code that detects projection queries that did not exist in v1 and was added in v2.

By the way, unrelated to this pull request, I found that TestMemcacheLimits fails when running tests in a go1.19 v2 environment.

The reason for this error is "The service bridge returned an exception." This is probably because the data processed by goon's GetMulti method exceeds the RPC limit.

The test errors are not directly related to the pull request, so I haven't changed them.

Please integrate if there is no problem.

Sincerely,